### PR TITLE
fix generate_models.sh script

### DIFF
--- a/scripts/generate_models.sh
+++ b/scripts/generate_models.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-./build/linux-debug/vcpkg_installed/x64-linux/tools/drogon/drogon_ctl create model server/src/models "$@"
+./build/linux-debug-server/vcpkg_installed/x64-linux/tools/drogon/drogon_ctl create model server/src/models "$@"
 
 # Loop over all .cc files in .server/src/models/
-for file in .server/src/models/*.cc; do
+for file in ./server/src/models/*.cc; do
   # Get the filename excluding .cc
   name=$(basename "$file" .cc)
 
@@ -12,5 +12,5 @@ for file in .server/src/models/*.cc; do
 done
 
 # Move all .h files from .server/src/models/ to .server/include/server/models/ with overwrite
-mkdir -p .server/include/server/models/
-mv -f .server/src/models/*.h .server/include/server/models/
+mkdir -p ./server/include/server/models/
+mv -f ./server/src/models/*.h ./server/include/server/models/


### PR DESCRIPTION
Очень маленький pr
Я случайно сломал `generate_models.sh` когда разделял сиходники на `common`, `server`, `client`
Теперь пофикшено :з

Resolves #14 