### PR TITLE
Refactor: Use prebuild devcontainer with all deps bundled in

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/cpp:noble
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake python3-jinja2 automake libtool pkg-config bison flex autoconf ninja-build libx11-dev libxft-dev libxext-dev libxi-dev libxtst-dev libxrandr-dev && \
-    rm -rf /var/lib/apt/lists/*
+FROM cuteboibutt/team_3_stuff:devcontainer_with_deps


### PR DESCRIPTION
Т.к. у нас ещё пока нету полноценного CI\CD сетапа, то мне пришлось собрать это руками
Как заимеем виртуалку то нужно будет написать отдельный Dockerfile и собрать там автоматом

Resolves #25 