### PR TITLE
CI: Update build-package-cached.yml

### DIFF
--- a/.github/workflows/build-package-cached.yml
+++ b/.github/workflows/build-package-cached.yml
@@ -46,6 +46,7 @@ jobs:
           # The keys we RESTORE from are the most recent successful run
           restore-keys: |
             ${{ runner.os }}-vcpkg-${{ hashFiles('.git/modules/vcpkg/HEAD') }}-
+            ${{ runner.os }}-vcpkg-
 
       # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly.
       # As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.


### PR DESCRIPTION
Гх полная помойка
Их кеш, вместо того чтобы по очереди проходиться по fallback ключам, просто берёт первый exact-match
Это поведение никак не задокументиированно, доки утверждают что в случае мисса по основному ключу оно восстановит самый свежий fallback, но оказывается это не так :)