### PR TITLE
Bug: fix invert scroll

### DIFF
--- a/client/src/messageView.cpp
+++ b/client/src/messageView.cpp
@@ -59,9 +59,9 @@ void MessageView::OnMouseWheel(wxMouseEvent& event) {
     int linesPerWheel = FromDIP(15);//event.GetLinesPerAction();
 
     // Calculate lines to scroll
-    int lines = (rotation * linesPerWheel) / delta;
+    int lines = -(rotation * linesPerWheel) / delta;
     if(lines == 0) {
-        lines = (rotation > 0) ? 1 : -1;
+        lines = (rotation > 0) ? -1 : 1;
     }
 
     if(ScrollRows(lines)) {


### PR DESCRIPTION
GetWheelRotation() возвращает >0 если колесиком крутить вверх, а ScrollRows наоборот при положительном числе скроллит вниз.
```
Scroll by the specified number of rows which may be positive (to scroll down) or negative (to scroll up).
```
Resolves #112