### PR TITLE
Bug: render emojis in user names on Windows

### DIFF
--- a/client/include/client/cachedColorText.h
+++ b/client/include/client/cachedColorText.h
@@ -10,13 +10,14 @@ class CachedColorText : public wxControl {
 public:
     CachedColorText(wxWindow* parent, wxWindowID id, const wxString& label,
         const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
-        long style = 0, const wxString& name = wxStaticTextNameStr);
+        long style = 0, const wxString& name = wxStaticTextNameStr, bool stretchToParentWidth = true);
 
     virtual void SetLabel(const wxString& label) override;
     virtual wxString GetLabel() const override;
     virtual bool SetFont(const wxFont& font) override;
     void InvalidateCache();
     void InvalidateCacheAndRefresh();
+    void InvalidateLayoutCaches();
 
 protected:
     virtual wxSize DoGetBestSize() const override;
@@ -28,8 +29,12 @@ private:
     void RenderToCache();
     wxDouble GetLineHeight() const;
 
+    bool m_stretchesToParentWidth;
+
     wxString m_label;
     wxBitmap m_cache;
+
+    mutable wxSize m_cachedBestSize;
     mutable double m_cachedLineHeight;
 
     wxDECLARE_EVENT_TABLE();

--- a/client/include/client/messageWidget.h
+++ b/client/include/client/messageWidget.h
@@ -29,7 +29,7 @@ private:
     CachedColorText* m_messageStaticText; // Pointer to the actual text control.
     int64_t m_timestamp_val;           // Stores the raw timestamp for sorting/querying
     wxStaticText* m_timeText;
-    wxStaticText* m_userText;
+    CachedColorText* m_userText;
 
     void OnRightClick(wxMouseEvent& event);
     void OnMouseEnter(wxMouseEvent& event);

--- a/client/include/client/userNameWidget.h
+++ b/client/include/client/userNameWidget.h
@@ -3,6 +3,8 @@
 #include <wx/wx.h>
 #include <client/user.h>
 
+class CachedColorText;
+
 class UserNameWidget : public wxPanel {
 public:
     UserNameWidget(wxWindow* parent, const User& user);
@@ -14,6 +16,6 @@ public:
 private:
     void OnRightClick(wxMouseEvent& event);
 
-    wxStaticText* m_usernameText;
+    CachedColorText* m_usernameText;
     User m_user;
 };

--- a/client/src/messageWidget.cpp
+++ b/client/src/messageWidget.cpp
@@ -23,11 +23,11 @@ MessageWidget::MessageWidget(wxWindow* parent,
     auto* headerSizer = new wxBoxSizer(wxHORIZONTAL);
 
     // Username (bold)
-    m_userText = new wxStaticText(this, wxID_ANY, msg.user);
+    m_userText = new CachedColorText(this, wxID_ANY, msg.user, wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT, wxStaticTextNameStr, false);
     wxFont userFont = m_userText->GetFont();
     userFont.SetWeight(wxFONTWEIGHT_BOLD);
     m_userText->SetFont(userFont);
-    m_userText->Wrap(-1);
+    //m_userText->Wrap(-1);
     m_userText->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
     headerSizer->Add(m_userText, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(5));
 
@@ -51,7 +51,7 @@ MessageWidget::MessageWidget(wxWindow* parent,
 
     m_messageStaticText = new CachedColorText(this, wxID_ANY, wrapped,
                                           wxDefaultPosition, wxDefaultSize,
-                                          wxALIGN_LEFT); // Ensure left alignment
+                                          wxALIGN_LEFT, wxStaticTextNameStr, true); // Ensure left alignment
     //m_messageStaticText->Wrap(-1);
     //m_messageStaticText->SetBackgroundColour(*wxYELLOW); // For debugging the text control width
 
@@ -129,6 +129,7 @@ void MessageWidget::OnRightClick(wxMouseEvent& event) {
 void MessageWidget::OnMouseEnter(wxMouseEvent& event) {
     SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
     m_messageStaticText->InvalidateCache();
+    m_userText->InvalidateCache();
     Refresh();
     event.Skip();
 }
@@ -140,6 +141,7 @@ void MessageWidget::OnMouseLeave(wxMouseEvent& event) {
     if (!GetClientRect().Contains(clientPos)) {
         SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
         m_messageStaticText->InvalidateCache();
+        m_userText->InvalidateCache();
         Refresh();
     }
     event.Skip();

--- a/client/src/userNameWidget.cpp
+++ b/client/src/userNameWidget.cpp
@@ -1,10 +1,13 @@
 #include <client/userNameWidget.h>
+#include <client/cachedColorText.h>
 
 UserNameWidget::UserNameWidget(wxWindow* parent, const User& user)
     : wxPanel(parent, wxID_ANY), m_user(user) {
+    SetBackgroundColour(parent->GetBackgroundColour());
+
     auto* sizer = new wxBoxSizer(wxHORIZONTAL);
-    m_usernameText = new wxStaticText(this, wxID_ANY, user.username);
-    m_usernameText->Wrap(-1);
+    m_usernameText = new CachedColorText(this, wxID_ANY, user.username, wxDefaultPosition, wxDefaultSize, 0, wxStaticTextNameStr, false);
+    //m_usernameText->Wrap(-1);
     // Set color based on role
     wxColour textColor;
     switch (user.role) {


### PR DESCRIPTION
Отрисовывает эмодзи в никах пользователей на Windows
В виджетах сообщений и в списке пользователей комнаты
`CachedColorText` теперь можно использовать как прямую замену wxStaticText если не нужен перенос строк(мы именно так и используем сейчас везде кроме тела сообщений, но это уже обрабатывается)