### PR TITLE
Bug: краш клиента при попытке сменить роль вышедшего из комнаты юзера

### DIFF
--- a/client/include/client/cachedColorText.h
+++ b/client/include/client/cachedColorText.h
@@ -17,6 +17,7 @@ public:
     virtual void SetLabel(const wxString& label) override;
     virtual wxString GetLabel() const override;
     virtual bool SetFont(const wxFont& font) override;
+    virtual bool SetForegroundColour(const wxColour& colour) override;
 
     void InvalidateCache();
     void InvalidateCacheAndRefresh();

--- a/client/include/client/userListPanel.h
+++ b/client/include/client/userListPanel.h
@@ -5,6 +5,7 @@
 namespace client {
 
 struct User;
+class UserNameWidget;
 
 class UserListPanel : public wxPanel {
 public:
@@ -19,9 +20,11 @@ public:
 private:
     void OnUserRightClick(wxMouseEvent& event);
 
+    void SortUserWidgets();
+
     wxScrolledWindow* m_userContainer;
     wxBoxSizer* m_userSizer;
-    std::vector<User> m_users;
+    std::unordered_map<int32_t, UserNameWidget*> m_userWidgets;
 };
 
 } // namespace client

--- a/client/include/client/userNameWidget.h
+++ b/client/include/client/userNameWidget.h
@@ -10,6 +10,7 @@ class CachedColorText;
 class UserNameWidget : public wxPanel {
 public:
     UserNameWidget(wxWindow* parent, const User& user);
+    void UpdateDisplay(const User& user);
 
     const User& GetUser() const {
         return m_user;
@@ -17,6 +18,7 @@ public:
 
 private:
     void PropagateRightClick(wxMouseEvent& event);
+    wxColour GetColourByRole(const User& user);
     
     CachedColorText* m_usernameText;
     User m_user;

--- a/client/src/cachedColorText.cpp
+++ b/client/src/cachedColorText.cpp
@@ -45,6 +45,17 @@ bool CachedColorText::SetFont(const wxFont& font) {
     return ret;
 }
 
+bool CachedColorText::SetForegroundColour(const wxColour& colour) {
+    if (GetForegroundColour() == colour) {
+        return false;
+    }
+    bool ret = wxControl::SetForegroundColour(colour);
+    if (ret) {
+        InvalidateCache();
+    }
+    return ret;
+}
+
 void CachedColorText::InvalidateCache() {
     m_cache = wxBitmap();
 }

--- a/client/src/userNameWidget.cpp
+++ b/client/src/userNameWidget.cpp
@@ -11,33 +11,38 @@ UserNameWidget::UserNameWidget(wxWindow* parent, const User& user)
     m_usernameText = new CachedColorText(this, wxID_ANY, user.username, wxDefaultPosition, wxDefaultSize, 0, wxStaticTextNameStr, false);
     //m_usernameText->Wrap(-1);
     // Set color based on role
-    wxColour textColor;
-    switch (user.role) {
-        case chat::UserRights::OWNER:
-            textColor = *wxRED;
-            break;
-        case chat::UserRights::ADMIN:
-            textColor = *wxGREEN;
-            break;
-        case chat::UserRights::MODERATOR:
-            textColor = *wxBLUE;
-            break;
-        case chat::UserRights::REGULAR:
-        default:
-            textColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
-            break;
-    }
-    m_usernameText->SetForegroundColour(textColor);
+    m_usernameText->SetForegroundColour(GetColourByRole(user));
 
     sizer->Add(m_usernameText, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
     SetSizer(sizer);
     m_usernameText->Bind(wxEVT_RIGHT_DOWN, &UserNameWidget::PropagateRightClick, this);
 }
 
+void UserNameWidget::UpdateDisplay(const User& user) {
+    m_user = user;
+    m_usernameText->SetLabel(user.username);
+    m_usernameText->SetForegroundColour(GetColourByRole(user));
+    m_usernameText->Refresh();
+}
+
 void UserNameWidget::PropagateRightClick(wxMouseEvent &event) {
     wxMouseEvent newEvent(event);
     newEvent.SetEventObject(this);
     ProcessWindowEvent(newEvent);
+}
+
+wxColour UserNameWidget::GetColourByRole(const User& user) {
+    switch (user.role) {
+    case chat::UserRights::OWNER:
+        return *wxRED;
+    case chat::UserRights::ADMIN:
+        return *wxGREEN;
+    case chat::UserRights::MODERATOR:
+        return *wxBLUE;
+    case chat::UserRights::REGULAR:
+    default:
+        return wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    }
 }
 
 } // namespace client


### PR DESCRIPTION
На самом деле этот ПР не решает проблему краша, тут я всего лишь поменял логику заполнения списка виджетами. Я убрал поле с вектором и сделал мапу id->userNameWidget* , что улучшает производительность ибо до этого у нас каждый раз перерисовывало полностью весь список, отсюда и вылезал баг - мы вызывали эвент с виджета, который убивался в последствии выхода юзера.
Теперь нужно добавить поддержку отображения "мемберов" комнаты исчезнет и баг с крашем ибо виджет пользователя будет вечно висеть в списке (не зависимо в комнате ли юзер или нет). Однако, если мы сделаем возможность выхода из комнаты - необходимо будет добавить проверку на существования юзера прямо в лямбде, где биндится меню 
```cpp
            menu.Bind(wxEVT_MENU, [this, targetUser](wxCommandEvent&) {
                wxCommandEvent newEvent(wxEVT_ASSIGN_MODERATOR, GetId());
                newEvent.SetEventObject(this);
                newEvent.SetInt(targetUser.id);
                ProcessEvent(newEvent);
            }, item->GetId());
```
где то тут. Ну или как-то по-другому, но уже в другом ПР и при добавлении возможности выхода из участников комнаты.